### PR TITLE
Add scripts for building on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ build/*
 .idea/
 .directory
 .clang-format
+# Windows
+local/
+prefix/

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -61,6 +61,7 @@ Install the following:
 * [Vulkan SDK](https://vulkan.lunarg.com/sdk/home#windows)
 * [Visual Studio Build Tools](https://visualstudio.microsoft.com/downloads/) (for a C++ compiler)
 * CMake (can be installed with the Visual Studio Build Tools)
+* [Rust](https://www.rust-lang.org/tools/install)
 
 Make sure your Qt bin (like `C:\Qt\6.7.0\msvc2019_64\bin`) is in your `PATH` environment variable before building, otherwise Qt will not be picked up by CMake.
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -62,4 +62,6 @@ Install the following:
 * [Visual Studio Build Tools](https://visualstudio.microsoft.com/downloads/) (for a C++ compiler)
 * CMake (can be installed with the Visual Studio Build Tools)
 
+Make sure your Qt bin (like `C:\Qt\6.7.0\msvc2019_64\bin`) is in your `PATH` environment variable before building, otherwise Qt will not be picked up by CMake.
+
 Afterwards, run `.\scripts\windows-setup.ps1` and `.\scripts\windows-build.ps1` in PowerShell.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -52,3 +52,14 @@ $ cmake --build build
 ```
 
 If the build was successful, the tool binaries will be found in `./build/bin`.
+
+## Windows
+
+Install the following:
+
+* [Qt 6.6](https://doc.qt.io/qt-6/get-and-install-qt.html) (with support for the HTTP Server and WebSockets)
+* [Vulkan SDK](https://vulkan.lunarg.com/sdk/home#windows)
+* [Visual Studio Build Tools](https://visualstudio.microsoft.com/downloads/) (for a C++ compiler)
+* CMake (can be installed with the Visual Studio Build Tools)
+
+Afterwards, run `.\scripts\windows-setup.ps1` and `.\scripts\windows-build.ps1` in PowerShell.

--- a/scripts/windows-build.ps1
+++ b/scripts/windows-build.ps1
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2024 NotNite <hi@notnite.com>
+# SPDX-License-Identifier: CC0-1.0
+
 $ErrorActionPreference = "Stop"
 $PSNativeCommandUseErrorActionPreference = $true
 

--- a/scripts/windows-build.ps1
+++ b/scripts/windows-build.ps1
@@ -1,0 +1,19 @@
+$ErrorActionPreference = "Stop"
+$PSNativeCommandUseErrorActionPreference = $true
+
+$LocalDir = "./local"
+$BuildDir = "./build"
+$PrefixDir = (Get-Location).Path + "/prefix"
+
+cmake -B "$BuildDir" "-DCMAKE_PREFIX_PATH=$PrefixDir" "-DCMAKE_CXX_COMPILER=cl" "-DCMAKE_C_COMPILER=cl" "-DCMAKE_BUILD_TYPE=Debug" "-S" . "-DCMAKE_INSTALL_PREFIX=$BuildDir"
+cmake --build "$BuildDir" --config Debug --target install
+
+Copy-Item -Path "$PrefixDir/bin/KF6ItemViews.dll" -Destination "$BuildDir/bin"
+Copy-Item -Path "$PrefixDir/bin/KF6IconWidgets.dll" -Destination "$BuildDir/bin"
+Copy-Item -Path "$PrefixDir/bin/KF6GuiAddons.dll" -Destination "$BuildDir/bin"
+Copy-Item -Path "$PrefixDir/bin/KF6ColorScheme.dll" -Destination "$BuildDir/bin"
+Copy-Item -Path "$PrefixDir/bin/intl-8.dll" -Destination "$BuildDir/bin"
+Copy-Item -Path "$PrefixDir/bin/KF6IconThemes.dll" -Destination "$BuildDir/bin"
+Copy-Item -Path "$PrefixDir/bin/iconv.dll" -Destination "$BuildDir/bin"
+Copy-Item -Path "$PrefixDir/bin/zlibd.dll" -Destination "$BuildDir/bin"
+Copy-Item -Path "$env:QTDIR/bin/Qt6PrintSupportd.dll" -Destination "$BuildDir/bin"

--- a/scripts/windows-setup.ps1
+++ b/scripts/windows-setup.ps1
@@ -27,6 +27,12 @@ function Clone($Name, $Url) {
     }
 }
 
+function CheckCompileResult($Name) {
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to build $Name!"
+    }
+}
+
 if (!(Test-Path $LocalDir)) {
     New-Item -ItemType Directory -Path $LocalDir
 }
@@ -45,12 +51,14 @@ Expand-Archive -Path "$LocalDir/gperf.zip" -DestinationPath $PrefixDir -Force
 Clone "zlib" "https://github.com/madler/zlib.git"
 Configure "zlib" "-DBUILD_TESTING=OFF"
 cmake --build "$BuildDir-zlib" --config Debug --target install
+CheckCompileResult "zlib"
 
 # Build Extra CMake Modules
 Clone "extra-cmake-modules" "https://invent.kde.org/frameworks/extra-cmake-modules.git"
 Configure "extra-cmake-modules" "-DBUILD_TESTING=OFF"
 cmake --build "$BuildDir-extra-cmake-modules" --config Debug --target install
 cmake --install "$BuildDir-extra-cmake-modules" --config Debug
+CheckCompileResult "extra-cmake-modules"
 
 # Build KI18n
 Clone "ki18n" "https://invent.kde.org/frameworks/ki18n.git"
@@ -59,41 +67,49 @@ Configure "ki18n" "-DBUILD_TESTING=OFF"
 
 (Get-Content -ReadCount 0 "$BuildDir-ki18n/cmake/build-pofiles.cmake") -replace 'FATAL_ERROR', 'WARNING' | Set-Content "$BuildDir-ki18n/cmake/build-pofiles.cmake"
 cmake --build "$BuildDir-ki18n" --config Debug --target install
+CheckCompileResult "ki18n"
 
 # Build KCoreAddons
 Clone "kcoreaddons" "https://invent.kde.org/frameworks/kcoreaddons.git"
 Configure "kcoreaddons" "-DBUILD_TESTING=OFF"
 cmake --build "$BuildDir-kcoreaddons" --config Debug --target install
+CheckCompileResult "kcoreaddons"
 
 # Build KConfig
 Clone "kconfig" "https://invent.kde.org/frameworks/kconfig.git"
 Configure "kconfig" "-DBUILD_TESTING=OFF"
 cmake --build "$BuildDir-kconfig" --config Debug --target install
+CheckCompileResult "kconfig"
 
 # Build KArchive
 Clone "karchive" "https://invent.kde.org/frameworks/karchive.git"
 Configure "karchive" "-DBUILD_TESTING=OFF" "-DWITH_BZIP2=OFF" "-DWITH_LIBLZMA=OFF" "-DWITH_LIBZSTD=OFF"
 cmake --build "$BuildDir-karchive" --config Debug --target install
+CheckCompileResult "karchive"
 
 # Build KItemViews
 Clone "kitemviews" "https://invent.kde.org/frameworks/kitemviews.git"
 Configure "kitemviews" "-DBUILD_TESTING=OFF"
 cmake --build "$BuildDir-kitemviews" --config Debug --target install
+CheckCompileResult "kitemviews"
 
 # Build KCodecs
 Clone "kcodecs" "https://invent.kde.org/frameworks/kcodecs.git"
 Configure "kcodecs" "-DBUILD_TESTING=OFF"
 cmake --build "$BuildDir-kcodecs" --config Debug --target install
+CheckCompileResult "kcodecs"
 
 # Build KGuiAddons
 Clone "kguiaddons" "https://invent.kde.org/frameworks/kguiaddons.git"
 Configure "kguiaddons" "-DBUILD_TESTING=OFF"
 cmake --build "$BuildDir-kguiaddons" --config Debug --target install
+CheckCompileResult "kguiaddons"
 
 # Build KWidgetsAddons
 Clone "kwidgetsaddons" "https://invent.kde.org/frameworks/kwidgetsaddons.git"
 Configure "kwidgetsaddons" "-DBUILD_TESTING=OFF"
 cmake --build "$BuildDir-kwidgetsaddons" --config Debug --target install
+CheckCompileResult "kwidgetsaddons"
 
 # Build KColorScheme
 Clone "kcolorscheme" "https://invent.kde.org/frameworks/kcolorscheme.git"
@@ -101,62 +117,75 @@ Configure "kcolorscheme" "-DBUILD_TESTING=OFF"
 # Workaround for Windows
 (Get-Content -ReadCount 0 "$PrefixDir/lib/cmake/KF6I18n/build-pofiles.cmake") -replace 'FATAL_ERROR', 'WARNING' | Set-Content "$PrefixDir/lib/cmake/KF6I18n/build-pofiles.cmake"
 cmake --build "$BuildDir-kcolorscheme" --config Debug --target install
+CheckCompileResult "kcolorscheme"
 
 # Build KConfigWidgets
 Clone "kconfigwidgets" "https://invent.kde.org/frameworks/kconfigwidgets.git"
 Configure "kconfigwidgets" "-DBUILD_TESTING=OFF"
 cmake --build "$BuildDir-kconfigwidgets" --config Debug --target install
+CheckCompileResult "kconfigwidgets"
 
 # Build KIconThemes
 Clone "kiconthemes" "https://invent.kde.org/frameworks/kiconthemes.git"
 Configure "kiconthemes" "-DBUILD_TESTING=OFF"
 cmake --build "$BuildDir-kiconthemes" --config Debug --target install
+CheckCompileResult "kiconthemes"
 
 # Build Sonnet
 Clone "sonnet" "https://invent.kde.org/frameworks/sonnet.git"
 Configure "sonnet" "-DBUILD_TESTING=OFF"
 cmake --build "$BuildDir-sonnet" --config Debug --target install
+CheckCompileResult "sonnet"
 
 # Build KCompletion
 Clone "kcompletion" "https://invent.kde.org/frameworks/kcompletion.git"
 Configure "kcompletion" "-DBUILD_TESTING=OFF"
 cmake --build "$BuildDir-kcompletion" --config Debug --target install
+CheckCompileResult "kcompletion"
 
 # Build KTextWidgets
 Clone "ktextwidgets" "https://invent.kde.org/frameworks/ktextwidgets.git"
 Configure "ktextwidgets" "-DBUILD_TESTING=OFF" "-DWITH_TEXT_TO_SPEECH=OFF"
 cmake --build "$BuildDir-ktextwidgets" --config Debug --target install
+CheckCompileResult "ktextwidgets"
 
 # Build KXmlGui
 Clone "kxmlgui" "https://invent.kde.org/frameworks/kxmlgui.git"
 Configure "kxmlgui" "-DBUILD_TESTING=OFF" "-DFORCE_DISABLE_KGLOBALACCEL=ON"
 cmake --build "$BuildDir-kxmlgui" --config Debug --target install
+CheckCompileResult "kxmlgui"
 
 # Build glm
 Clone "glm" "https://github.com/g-truc/glm.git"
 Configure "glm" "-DGLM_BUILD_TESTS=OFF"
 cmake --build "$BuildDir-glm" --config Debug --target install
+CheckCompileResult "glm"
 
 # Build Corrosion
 Clone "corrosion" "https://github.com/corrosion-rs/corrosion.git"
 Configure "corrosion" "-DCORROSION_BUILD_TESTS=OFF"
 cmake --build "$BuildDir-corrosion" --config Debug --target install
+CheckCompileResult "corrosion"
 
 # Build nlohmann
 Clone "json" "https://github.com/nlohmann/json.git"
 Configure "json" "-DJSON_BuildTests=OFF"
 cmake --build "$BuildDir-json" --config Debug --target install
+CheckCompileResult "json"
 
 # Build stb
 Clone "stb" "https://github.com/nothings/stb.git"
 mv $LocalDir/stb/* $PrefixDir/include
+CheckCompileResult "stb"
 
 # Build SPIRV-Cross
 Clone "SPIRV-Cross" "https://github.com/KhronosGroup/SPIRV-Cross.git"
 Configure "SPIRV-Cross"
 cmake --build "$BuildDir-SPIRV-Cross" --config Debug --target install
+CheckCompileResult "SPIRV-Cross"
 
 # Build SPIRV-Headers
 Clone "SPIRV-Headers" "https://github.com/KhronosGroup/SPIRV-Headers.git"
 Configure "SPIRV-Headers"
 cmake --build "$BuildDir-SPIRV-Headers" --config Debug --target install
+CheckCompileResult "SPIRV-Headers"

--- a/scripts/windows-setup.ps1
+++ b/scripts/windows-setup.ps1
@@ -87,7 +87,7 @@ CheckCompileResult "kconfig"
 
 # Build KArchive
 Clone "karchive" "https://invent.kde.org/frameworks/karchive.git"
-Configure "karchive" "-DBUILD_TESTING=OFF" "-DWITH_BZIP2=OFF" "-DWITH_LIBLZMA=OFF" "-DWITH_LIBZSTD=OFF"
+Configure "karchive" "-DBUILD_TESTING=OFF -DWITH_BZIP2=OFF -DWITH_LIBLZMA=OFF -DWITH_LIBZSTD=OFF"
 cmake --build "$BuildDir-karchive" --config Debug --target install --parallel $NumCores
 CheckCompileResult "karchive"
 
@@ -149,13 +149,13 @@ CheckCompileResult "kcompletion"
 
 # Build KTextWidgets
 Clone "ktextwidgets" "https://invent.kde.org/frameworks/ktextwidgets.git"
-Configure "ktextwidgets" "-DBUILD_TESTING=OFF" "-DWITH_TEXT_TO_SPEECH=OFF"
+Configure "ktextwidgets" "-DBUILD_TESTING=OFF -DWITH_TEXT_TO_SPEECH=OFF"
 cmake --build "$BuildDir-ktextwidgets" --config Debug --target install --parallel $NumCores
 CheckCompileResult "ktextwidgets"
 
 # Build KXmlGui
 Clone "kxmlgui" "https://invent.kde.org/frameworks/kxmlgui.git"
-Configure "kxmlgui" "-DBUILD_TESTING=OFF" "-DFORCE_DISABLE_KGLOBALACCEL=ON"
+Configure "kxmlgui" "-DBUILD_TESTING=OFF -DFORCE_DISABLE_KGLOBALACCEL=ON"
 cmake --build "$BuildDir-kxmlgui" --config Debug --target install --parallel $NumCores
 CheckCompileResult "kxmlgui"
 

--- a/scripts/windows-setup.ps1
+++ b/scripts/windows-setup.ps1
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2024 NotNite <hi@notnite.com>
+# SPDX-License-Identifier: CC0-1.0
+
 $ErrorActionPreference = "Stop"
 $PSNativeCommandUseErrorActionPreference = $true
 

--- a/scripts/windows-setup.ps1
+++ b/scripts/windows-setup.ps1
@@ -8,6 +8,8 @@ $LocalDir = "./local"
 $BuildDir = "$LocalDir/build"
 $PrefixDir = (Get-Location).Path + "/prefix"
 
+$NumCores = [Environment]::ProcessorCount
+
 function Configure($Name, $ExtraArgs = "") {
     $Command = "cmake -B $BuildDir-$Name -DCMAKE_PREFIX_PATH=$PrefixDir -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER=cl -DCMAKE_BUILD_TYPE=Debug -S $LocalDir/$Name -DCMAKE_INSTALL_PREFIX=$PrefixDir $ExtraArgs"
     Write-Output "Running $Command"
@@ -58,7 +60,7 @@ CheckCompileResult "zlib"
 # Build Extra CMake Modules
 Clone "extra-cmake-modules" "https://invent.kde.org/frameworks/extra-cmake-modules.git"
 Configure "extra-cmake-modules" "-DBUILD_TESTING=OFF"
-cmake --build "$BuildDir-extra-cmake-modules" --config Debug --target install
+cmake --build "$BuildDir-extra-cmake-modules" --config Debug --target install --parallel $NumCores
 cmake --install "$BuildDir-extra-cmake-modules" --config Debug
 CheckCompileResult "extra-cmake-modules"
 
@@ -68,49 +70,49 @@ Clone "ki18n" "https://invent.kde.org/frameworks/ki18n.git"
 Configure "ki18n" "-DBUILD_TESTING=OFF"
 
 (Get-Content -ReadCount 0 "$BuildDir-ki18n/cmake/build-pofiles.cmake") -replace 'FATAL_ERROR', 'WARNING' | Set-Content "$BuildDir-ki18n/cmake/build-pofiles.cmake"
-cmake --build "$BuildDir-ki18n" --config Debug --target install
+cmake --build "$BuildDir-ki18n" --config Debug --target install --parallel $NumCores
 CheckCompileResult "ki18n"
 
 # Build KCoreAddons
 Clone "kcoreaddons" "https://invent.kde.org/frameworks/kcoreaddons.git"
 Configure "kcoreaddons" "-DBUILD_TESTING=OFF"
-cmake --build "$BuildDir-kcoreaddons" --config Debug --target install
+cmake --build "$BuildDir-kcoreaddons" --config Debug --target install --parallel $NumCores
 CheckCompileResult "kcoreaddons"
 
 # Build KConfig
 Clone "kconfig" "https://invent.kde.org/frameworks/kconfig.git"
 Configure "kconfig" "-DBUILD_TESTING=OFF"
-cmake --build "$BuildDir-kconfig" --config Debug --target install
+cmake --build "$BuildDir-kconfig" --config Debug --target install --parallel $NumCores
 CheckCompileResult "kconfig"
 
 # Build KArchive
 Clone "karchive" "https://invent.kde.org/frameworks/karchive.git"
 Configure "karchive" "-DBUILD_TESTING=OFF" "-DWITH_BZIP2=OFF" "-DWITH_LIBLZMA=OFF" "-DWITH_LIBZSTD=OFF"
-cmake --build "$BuildDir-karchive" --config Debug --target install
+cmake --build "$BuildDir-karchive" --config Debug --target install --parallel $NumCores
 CheckCompileResult "karchive"
 
 # Build KItemViews
 Clone "kitemviews" "https://invent.kde.org/frameworks/kitemviews.git"
 Configure "kitemviews" "-DBUILD_TESTING=OFF"
-cmake --build "$BuildDir-kitemviews" --config Debug --target install
+cmake --build "$BuildDir-kitemviews" --config Debug --target install --parallel $NumCores
 CheckCompileResult "kitemviews"
 
 # Build KCodecs
 Clone "kcodecs" "https://invent.kde.org/frameworks/kcodecs.git"
 Configure "kcodecs" "-DBUILD_TESTING=OFF"
-cmake --build "$BuildDir-kcodecs" --config Debug --target install
+cmake --build "$BuildDir-kcodecs" --config Debug --target install --parallel $NumCores
 CheckCompileResult "kcodecs"
 
 # Build KGuiAddons
 Clone "kguiaddons" "https://invent.kde.org/frameworks/kguiaddons.git"
 Configure "kguiaddons" "-DBUILD_TESTING=OFF"
-cmake --build "$BuildDir-kguiaddons" --config Debug --target install
+cmake --build "$BuildDir-kguiaddons" --config Debug --target install --parallel $NumCores
 CheckCompileResult "kguiaddons"
 
 # Build KWidgetsAddons
 Clone "kwidgetsaddons" "https://invent.kde.org/frameworks/kwidgetsaddons.git"
 Configure "kwidgetsaddons" "-DBUILD_TESTING=OFF"
-cmake --build "$BuildDir-kwidgetsaddons" --config Debug --target install
+cmake --build "$BuildDir-kwidgetsaddons" --config Debug --target install --parallel $NumCores
 CheckCompileResult "kwidgetsaddons"
 
 # Build KColorScheme
@@ -118,61 +120,61 @@ Clone "kcolorscheme" "https://invent.kde.org/frameworks/kcolorscheme.git"
 Configure "kcolorscheme" "-DBUILD_TESTING=OFF"
 # Workaround for Windows
 (Get-Content -ReadCount 0 "$PrefixDir/lib/cmake/KF6I18n/build-pofiles.cmake") -replace 'FATAL_ERROR', 'WARNING' | Set-Content "$PrefixDir/lib/cmake/KF6I18n/build-pofiles.cmake"
-cmake --build "$BuildDir-kcolorscheme" --config Debug --target install
+cmake --build "$BuildDir-kcolorscheme" --config Debug --target install --parallel $NumCores
 CheckCompileResult "kcolorscheme"
 
 # Build KConfigWidgets
 Clone "kconfigwidgets" "https://invent.kde.org/frameworks/kconfigwidgets.git"
 Configure "kconfigwidgets" "-DBUILD_TESTING=OFF"
-cmake --build "$BuildDir-kconfigwidgets" --config Debug --target install
+cmake --build "$BuildDir-kconfigwidgets" --config Debug --target install --parallel $NumCores
 CheckCompileResult "kconfigwidgets"
 
 # Build KIconThemes
 Clone "kiconthemes" "https://invent.kde.org/frameworks/kiconthemes.git"
 Configure "kiconthemes" "-DBUILD_TESTING=OFF"
-cmake --build "$BuildDir-kiconthemes" --config Debug --target install
+cmake --build "$BuildDir-kiconthemes" --config Debug --target install --parallel $NumCores
 CheckCompileResult "kiconthemes"
 
 # Build Sonnet
 Clone "sonnet" "https://invent.kde.org/frameworks/sonnet.git"
 Configure "sonnet" "-DBUILD_TESTING=OFF"
-cmake --build "$BuildDir-sonnet" --config Debug --target install
+cmake --build "$BuildDir-sonnet" --config Debug --target install --parallel $NumCores
 CheckCompileResult "sonnet"
 
 # Build KCompletion
 Clone "kcompletion" "https://invent.kde.org/frameworks/kcompletion.git"
 Configure "kcompletion" "-DBUILD_TESTING=OFF"
-cmake --build "$BuildDir-kcompletion" --config Debug --target install
+cmake --build "$BuildDir-kcompletion" --config Debug --target install --parallel $NumCores
 CheckCompileResult "kcompletion"
 
 # Build KTextWidgets
 Clone "ktextwidgets" "https://invent.kde.org/frameworks/ktextwidgets.git"
 Configure "ktextwidgets" "-DBUILD_TESTING=OFF" "-DWITH_TEXT_TO_SPEECH=OFF"
-cmake --build "$BuildDir-ktextwidgets" --config Debug --target install
+cmake --build "$BuildDir-ktextwidgets" --config Debug --target install --parallel $NumCores
 CheckCompileResult "ktextwidgets"
 
 # Build KXmlGui
 Clone "kxmlgui" "https://invent.kde.org/frameworks/kxmlgui.git"
 Configure "kxmlgui" "-DBUILD_TESTING=OFF" "-DFORCE_DISABLE_KGLOBALACCEL=ON"
-cmake --build "$BuildDir-kxmlgui" --config Debug --target install
+cmake --build "$BuildDir-kxmlgui" --config Debug --target install --parallel $NumCores
 CheckCompileResult "kxmlgui"
 
 # Build glm
 Clone "glm" "https://github.com/g-truc/glm.git"
 Configure "glm" "-DGLM_BUILD_TESTS=OFF"
-cmake --build "$BuildDir-glm" --config Debug --target install
+cmake --build "$BuildDir-glm" --config Debug --target install --parallel $NumCores
 CheckCompileResult "glm"
 
 # Build Corrosion
 Clone "corrosion" "https://github.com/corrosion-rs/corrosion.git"
 Configure "corrosion" "-DCORROSION_BUILD_TESTS=OFF"
-cmake --build "$BuildDir-corrosion" --config Debug --target install
+cmake --build "$BuildDir-corrosion" --config Debug --target install --parallel $NumCores
 CheckCompileResult "corrosion"
 
 # Build nlohmann
 Clone "json" "https://github.com/nlohmann/json.git"
 Configure "json" "-DJSON_BuildTests=OFF"
-cmake --build "$BuildDir-json" --config Debug --target install
+cmake --build "$BuildDir-json" --config Debug --target install --parallel $NumCores
 CheckCompileResult "json"
 
 # Build stb
@@ -183,11 +185,11 @@ CheckCompileResult "stb"
 # Build SPIRV-Cross
 Clone "SPIRV-Cross" "https://github.com/KhronosGroup/SPIRV-Cross.git"
 Configure "SPIRV-Cross"
-cmake --build "$BuildDir-SPIRV-Cross" --config Debug --target install
+cmake --build "$BuildDir-SPIRV-Cross" --config Debug --target install --parallel $NumCores
 CheckCompileResult "SPIRV-Cross"
 
 # Build SPIRV-Headers
 Clone "SPIRV-Headers" "https://github.com/KhronosGroup/SPIRV-Headers.git"
 Configure "SPIRV-Headers"
-cmake --build "$BuildDir-SPIRV-Headers" --config Debug --target install
+cmake --build "$BuildDir-SPIRV-Headers" --config Debug --target install --parallel $NumCores
 CheckCompileResult "SPIRV-Headers"

--- a/scripts/windows-setup.ps1
+++ b/scripts/windows-setup.ps1
@@ -1,0 +1,147 @@
+$ErrorActionPreference = "Stop"
+$PSNativeCommandUseErrorActionPreference = $true
+
+$LocalDir = "./local"
+$BuildDir = "$LocalDir/build"
+$PrefixDir = (Get-Location).Path + "/prefix"
+
+function Configure($Name, $Args = "") {
+    cmake -B "$BuildDir-$Name" "-DCMAKE_PREFIX_PATH=$PrefixDir" "-DCMAKE_CXX_COMPILER=cl" "-DCMAKE_C_COMPILER=cl" "-DCMAKE_BUILD_TYPE=Debug" "-S" "$LocalDir/$Name" "-DCMAKE_INSTALL_PREFIX=$PrefixDir" $Args
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to configure $Name"
+    }
+}
+
+if (!(Test-Path $LocalDir)) {
+    New-Item -ItemType Directory -Path $LocalDir
+}
+
+# Setup Windows dependencies
+Invoke-WebRequest https://xiv.zone/distrib/dependencies/gettext.zip -OutFile "$LocalDir/gettext.zip"
+Expand-Archive -Path "$LocalDir/gettext.zip" -DestinationPath $PrefixDir -Force
+
+Invoke-WebRequest https://xiv.zone/distrib/dependencies/iconv.zip -OutFile "$LocalDir/iconv.zip"
+Expand-Archive -Path "$LocalDir/iconv.zip" -DestinationPath $PrefixDir -Force
+
+Invoke-WebRequest https://cfhcable.dl.sourceforge.net/project/gnuwin32/gperf/3.0.1/gperf-3.0.1-bin.zip -OutFile "$LocalDir/gperf.zip"
+Expand-Archive -Path "$LocalDir/gperf.zip" -DestinationPath $PrefixDir -Force
+
+# Build zlib
+git clone "https://github.com/madler/zlib.git" "$LocalDir/zlib"
+Configure "zlib" "-DBUILD_TESTING=OFF"
+cmake --build "$BuildDir-zlib" --config Debug --target install
+
+# Build Extra CMake Modules
+git clone https://invent.kde.org/frameworks/extra-cmake-modules.git "$LocalDir/extra-cmake-modules"
+Configure "extra-cmake-modules" "-DBUILD_TESTING=OFF"
+cmake --build "$BuildDir-extra-cmake-modules" --config Debug --target install
+cmake --install "$BuildDir-extra-cmake-modules" --config Debug
+
+# Build KI18n
+git clone https://invent.kde.org/frameworks/ki18n.git "$LocalDir/ki18n"
+# Workaround for Windows
+Configure "ki18n" "-DBUILD_TESTING=OFF"
+
+(Get-Content -ReadCount 0 "$BuildDir-ki18n/cmake/build-pofiles.cmake") -replace 'FATAL_ERROR', 'WARNING' | Set-Content "$BuildDir-ki18n/cmake/build-pofiles.cmake"
+cmake --build "$BuildDir-ki18n" --config Debug --target install
+
+# Build KCoreAddons
+git clone https://invent.kde.org/frameworks/kcoreaddons.git "$LocalDir/kcoreaddons"
+Configure "kcoreaddons" "-DBUILD_TESTING=OFF"
+cmake --build "$BuildDir-kcoreaddons" --config Debug --target install
+
+# Build KConfig
+git clone https://invent.kde.org/frameworks/kconfig.git "$LocalDir/kconfig"
+Configure "kconfig" "-DBUILD_TESTING=OFF"
+cmake --build "$BuildDir-kconfig" --config Debug --target install
+
+# Build KArchive
+git clone https://invent.kde.org/frameworks/karchive.git "$LocalDir/karchive"
+Configure "karchive" "-DBUILD_TESTING=OFF" "-DWITH_BZIP2=OFF" "-DWITH_LIBLZMA=OFF" "-DWITH_LIBZSTD=OFF"
+cmake --build "$BuildDir-karchive" --config Debug --target install
+
+# Build KItemViews
+git clone https://invent.kde.org/frameworks/kitemviews.git "$LocalDir/kitemviews"
+Configure "kitemviews" "-DBUILD_TESTING=OFF"
+cmake --build "$BuildDir-kitemviews" --config Debug --target install
+
+# Build KCodecs
+git clone https://invent.kde.org/frameworks/kcodecs.git "$LocalDir/kcodecs"
+Configure "kcodecs" "-DBUILD_TESTING=OFF"
+cmake --build "$BuildDir-kcodecs" --config Debug --target install
+
+# Build KGuiAddons
+git clone https://invent.kde.org/frameworks/kguiaddons.git "$LocalDir/kguiaddons"
+Configure "kguiaddons" "-DBUILD_TESTING=OFF"
+cmake --build "$BuildDir-kguiaddons" --config Debug --target install
+
+# Build KWidgetsAddons
+git clone https://invent.kde.org/frameworks/kwidgetsaddons.git "$LocalDir/kwidgetsaddons"
+Configure "kwidgetsaddons" "-DBUILD_TESTING=OFF"
+cmake --build "$BuildDir-kwidgetsaddons" --config Debug --target install
+
+# Build KColorScheme
+git clone https://invent.kde.org/frameworks/kcolorscheme.git "$LocalDir/kcolorscheme"
+Configure "kcolorscheme" "-DBUILD_TESTING=OFF"
+# Workaround for Windows
+(Get-Content -ReadCount 0 "$PrefixDir/lib/cmake/KF6I18n/build-pofiles.cmake") -replace 'FATAL_ERROR', 'WARNING' | Set-Content "$PrefixDir/lib/cmake/KF6I18n/build-pofiles.cmake"
+cmake --build "$BuildDir-kcolorscheme" --config Debug --target install
+
+# Build KConfigWidgets
+git clone https://invent.kde.org/frameworks/kconfigwidgets.git "$LocalDir/kconfigwidgets"
+Configure "kconfigwidgets" "-DBUILD_TESTING=OFF"
+cmake --build "$BuildDir-kconfigwidgets" --config Debug --target install
+
+# Build KIconThemes
+git clone https://invent.kde.org/frameworks/kiconthemes.git "$LocalDir/kiconthemes"
+Configure "kiconthemes" "-DBUILD_TESTING=OFF"
+cmake --build "$BuildDir-kiconthemes" --config Debug --target install
+
+# Build Sonnet
+git clone https://invent.kde.org/frameworks/sonnet.git "$LocalDir/sonnet"
+Configure "sonnet" "-DBUILD_TESTING=OFF"
+cmake --build "$BuildDir-sonnet" --config Debug --target install
+
+# Build KCompletion
+git clone https://invent.kde.org/frameworks/kcompletion.git "$LocalDir/kcompletion"
+Configure "kcompletion" "-DBUILD_TESTING=OFF"
+cmake --build "$BuildDir-kcompletion" --config Debug --target install
+
+# Build KTextWidgets
+git clone https://invent.kde.org/frameworks/ktextwidgets.git "$LocalDir/ktextwidgets"
+Configure "ktextwidgets" "-DBUILD_TESTING=OFF" "-DWITH_TEXT_TO_SPEECH=OFF"
+cmake --build "$BuildDir-ktextwidgets" --config Debug --target install
+
+# Build KXmlGui
+git clone https://invent.kde.org/frameworks/kxmlgui.git "$LocalDir/kxmlgui"
+Configure "kxmlgui" "-DBUILD_TESTING=OFF" "-DFORCE_DISABLE_KGLOBALACCEL=ON"
+cmake --build "$BuildDir-kxmlgui" --config Debug --target install
+
+# Build glm
+git clone https://github.com/g-truc/glm.git "$LocalDir/glm"
+Configure "glm" "-DGLM_BUILD_TESTS=OFF"
+cmake --build "$BuildDir-glm" --config Debug --target install
+
+# Build Corrosion
+git clone https://github.com/corrosion-rs/corrosion.git "$LocalDir/corrosion"
+Configure "corrosion" "-DCORROSION_BUILD_TESTS=OFF"
+cmake --build "$BuildDir-corrosion" --config Debug --target install
+
+# Build nlohmann
+git clone https://github.com/nlohmann/json.git "$LocalDir/json"
+Configure "json" "-DJSON_BuildTests=OFF"
+cmake --build "$BuildDir-json" --config Debug --target install
+
+# Build stb
+git clone https://github.com/nothings/stb.git "$LocalDir/stb"
+mv $LocalDir/stb/* $PrefixDir/include
+
+# Build SPIRV-Cross
+git clone https://github.com/KhronosGroup/SPIRV-Cross.git "$LocalDir/SPIRV-Cross"
+Configure "SPIRV-Cross"
+cmake --build "$BuildDir-SPIRV-Cross" --config Debug --target install
+
+# Build SPIRV-Headers
+git clone https://github.com/KhronosGroup/SPIRV-Headers.git "$LocalDir/SPIRV-Headers"
+Configure "SPIRV-Headers"
+cmake --build "$BuildDir-SPIRV-Headers" --config Debug --target install

--- a/scripts/windows-setup.ps1
+++ b/scripts/windows-setup.ps1
@@ -8,8 +8,10 @@ $LocalDir = "./local"
 $BuildDir = "$LocalDir/build"
 $PrefixDir = (Get-Location).Path + "/prefix"
 
-function Configure($Name, $Args = "") {
-    cmake -B "$BuildDir-$Name" "-DCMAKE_PREFIX_PATH=$PrefixDir" "-DCMAKE_CXX_COMPILER=cl" "-DCMAKE_C_COMPILER=cl" "-DCMAKE_BUILD_TYPE=Debug" "-S" "$LocalDir/$Name" "-DCMAKE_INSTALL_PREFIX=$PrefixDir" $Args
+function Configure($Name, $ExtraArgs = "") {
+    $Command = "cmake -B $BuildDir-$Name -DCMAKE_PREFIX_PATH=$PrefixDir -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER=cl -DCMAKE_BUILD_TYPE=Debug -S $LocalDir/$Name -DCMAKE_INSTALL_PREFIX=$PrefixDir $ExtraArgs"
+    Write-Output "Running $Command"
+    Invoke-Expression $Command
     if ($LASTEXITCODE -ne 0) {
         throw "Failed to configure $Name"
     }


### PR DESCRIPTION
Adds some scripts for building all the dependencies, adapted from the action. The primary goal of this is to make developing Novus on Windows as easy as possible. The action does not use this script (but it could!). It uses a `prefix` dir to install everything and a `local` dir for the cloned sources.

I've only tested this on my local machine and it seems to work OK, but I have yet to test it on a not-contaminated-with-years-of-code machine (or from a completely fresh build, given it takes several minutes).

