### PR TITLE
various windows build fixes/improvements

### DIFF
--- a/parts/scene/animation.cpp
+++ b/parts/scene/animation.cpp
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Joshua Goins <josh@redstrate.com>
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include <span>
+
 #include "animation.h"
 
 #include "scenestate.h"

--- a/scripts/windows-build.ps1
+++ b/scripts/windows-build.ps1
@@ -18,5 +18,9 @@ Copy-Item -Path "$PrefixDir/bin/KF6ColorScheme.dll" -Destination "$BuildDir/bin"
 Copy-Item -Path "$PrefixDir/bin/intl-8.dll" -Destination "$BuildDir/bin"
 Copy-Item -Path "$PrefixDir/bin/KF6IconThemes.dll" -Destination "$BuildDir/bin"
 Copy-Item -Path "$PrefixDir/bin/iconv.dll" -Destination "$BuildDir/bin"
-Copy-Item -Path "$PrefixDir/bin/zlibd.dll" -Destination "$BuildDir/bin"
+Copy-Item -Path "$PrefixDir/bin/zd.dll" -Destination "$BuildDir/bin"
 Copy-Item -Path "$env:QTDIR/bin/Qt6PrintSupportd.dll" -Destination "$BuildDir/bin"
+if (!(Test-Path "$BuildDir/plugins/sqldrivers")) {
+    New-Item -ItemType Directory -Path "$BuildDir/plugins/sqldrivers"
+}
+Copy-Item -Path "$env:QTDIR/plugins/sqldrivers/qsqlited.dll" -Destination "$BuildDir/plugins/sqldrivers"


### PR DESCRIPTION
worked on getting this building on windows for me to investigate the issue w/ data explorer not launching, made a few improvements to the windows build scripts too while i was in there.

changes:
- switch Configure helper function to use a list of args instead of a single string, so that e.g. paths with spaces won't break it (?probably at least, I didn't actually have any spaces in the paths of mine so idk)
- move `breeze-icons` build to above `kiconthemes`, since build for the latter was failing from the former not being there yet
- skip re-downloading zips if they've already been downloaded (same as how cloning of git repos was already handled)
- added one stray include that was missing
- change copied dll name from zlibd.dll to zd.dll
- add copying of qsqlited.dll which is required for DataExplorer (this closes #20 and i can confirm DataExplorer built after making this change launches for me)

a couple other notes from stuff i ran into, but which aren't changed in this PR:
- windows-build.ps1 needs QTDIR environment variable to be set, not mentioned in BUILDING.md
- Qt 9 was the lowest version that worked (QT_MIN_VERSION is 8 and BUILDING.md mentions Qt 6)
- needs a python version with lxml installed (the CI scripts already handle this but the build docs should probably mention it for manual builds)
- the copying over of the sqlite dll would also need to be added to the CI scripts, I only added it to the powershell build script here
